### PR TITLE
[WIP] Add table_type literal to SnowflakeOnlineStoreConfig

### DIFF
--- a/sdk/python/feast/infra/materialization/snowflake_engine.py
+++ b/sdk/python/feast/infra/materialization/snowflake_engine.py
@@ -29,7 +29,7 @@ from feast.infra.utils.snowflake.snowflake_utils import (
     assert_snowflake_feature_names,
     execute_snowflake_statement,
     get_snowflake_conn,
-    get_snowflake_online_store_path,
+    get_snowflake_online_table_fully_qualified_name,
     package_snowpark_zip,
 )
 from feast.protos.feast.types.EntityKey_pb2 import EntityKey as EntityKeyProto
@@ -389,8 +389,7 @@ class SnowflakeMaterializationEngine(BatchMaterializationEngine):
         else:
             fv_created_str = None
 
-        online_path = get_snowflake_online_store_path(repo_config, feature_view)
-        online_table = f'{online_path}."{repo_config.online_store.table_typ_fqn} {project}_{feature_view.name}"'
+        online_table = get_snowflake_online_table_fully_qualified_name(repo_config, feature_view)
 
         query = f"""
             SELECT

--- a/sdk/python/feast/infra/materialization/snowflake_engine.py
+++ b/sdk/python/feast/infra/materialization/snowflake_engine.py
@@ -390,7 +390,7 @@ class SnowflakeMaterializationEngine(BatchMaterializationEngine):
             fv_created_str = None
 
         online_path = get_snowflake_online_store_path(repo_config, feature_view)
-        online_table = f'{online_path}."[online-hybrid] {project}_{feature_view.name}"'
+        online_table = f'{online_path}."{repo_config.online_store.table_type} {project}_{feature_view.name}"'
 
         query = f"""
             SELECT

--- a/sdk/python/feast/infra/materialization/snowflake_engine.py
+++ b/sdk/python/feast/infra/materialization/snowflake_engine.py
@@ -390,7 +390,7 @@ class SnowflakeMaterializationEngine(BatchMaterializationEngine):
             fv_created_str = None
 
         online_path = get_snowflake_online_store_path(repo_config, feature_view)
-        online_table = f'{online_path}."{repo_config.online_store.table_type} {project}_{feature_view.name}"'
+        online_table = f'{online_path}."{repo_config.online_store.table_typ_fqn} {project}_{feature_view.name}"'
 
         query = f"""
             SELECT

--- a/sdk/python/feast/infra/online_stores/snowflake.py
+++ b/sdk/python/feast/infra/online_stores/snowflake.py
@@ -1,5 +1,6 @@
 import itertools
 import os
+import re
 from binascii import hexlify
 from datetime import datetime
 from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple
@@ -57,6 +58,9 @@ class SnowflakeOnlineStoreConfig(FeastConfigBaseModel):
 
     schema_: Optional[str] = Field("PUBLIC", alias="schema")
     """ Snowflake schema name """
+
+    table_type: Literal["[online-hybrid]", "[online-transient]"] = ["online-transient"]
+    """ Online store table type"""
 
     class Config:
         allow_population_by_field_name = True
@@ -118,13 +122,13 @@ class SnowflakeOnlineStore(OnlineStore):
                 write_pandas_binary(
                     conn,
                     agg_df,
-                    table_name=f"[online-hybrid] {config.project}_{table.name}",
+                    table_name=f"{config.online_store.table_type} {config.project}_{table.name}",
                     database=f"{config.online_store.database}",
                     schema=f"{config.online_store.schema_}",
                 )  # special function for writing binary to snowflake
 
                 query = f"""
-                    INSERT OVERWRITE INTO {online_path}."[online-hybrid] {config.project}_{table.name}"
+                    INSERT OVERWRITE INTO {online_path}."{config.online_store.table_type} {config.project}_{table.name}"
                         SELECT
                             "entity_feature_key",
                             "entity_key",
@@ -137,7 +141,7 @@ class SnowflakeOnlineStore(OnlineStore):
                               *,
                               ROW_NUMBER() OVER(PARTITION BY "entity_key","feature_name" ORDER BY "event_ts" DESC, "created_ts" DESC) AS "_feast_row"
                           FROM
-                              {online_path}."[online-hybrid] {config.project}_{table.name}")
+                              {online_path}."{config.online_store.table_type} {config.project}_{table.name}")
                         WHERE
                             "_feast_row" = 1;
                 """
@@ -183,7 +187,7 @@ class SnowflakeOnlineStore(OnlineStore):
                 SELECT
                     "entity_key", "feature_name", "value", "event_ts"
                 FROM
-                    {online_path}."[online-hybrid] {config.project}_{table.name}"
+                    {online_path}."{config.online_store.table_type} {config.project}_{table.name}"
                 WHERE
                     "entity_feature_key" IN ({entity_fetch_str})
             """
@@ -223,8 +227,9 @@ class SnowflakeOnlineStore(OnlineStore):
         with get_snowflake_conn(config.online_store) as conn:
             for table in tables_to_keep:
                 online_path = get_snowflake_online_store_path(config, table)
+                table_type = re.search(r"^\[\S+\-(\S*)\]$", config.online_store.table_type).group(1).upper()
                 query = f"""
-                    CREATE HYBRID TABLE IF NOT EXISTS {online_path}."[online-hybrid] {config.project}_{table.name}" (
+                    CREATE {table_type} TABLE IF NOT EXISTS {online_path}."{config.online_store.table_type} {config.project}_{table.name}" (
                         "entity_feature_key" BINARY PRIMARY KEY,
                         "entity_key" BINARY,
                         "feature_name" VARCHAR,
@@ -237,7 +242,7 @@ class SnowflakeOnlineStore(OnlineStore):
 
             for table in tables_to_delete:
                 online_path = get_snowflake_online_store_path(config, table)
-                query = f'DROP TABLE IF EXISTS {online_path}."[online-hybrid] {config.project}_{table.name}"'
+                query = f'DROP TABLE IF EXISTS {online_path}."{config.online_store.table_type} {config.project}_{table.name}"'
                 execute_snowflake_statement(conn, query)
 
     def teardown(
@@ -251,5 +256,5 @@ class SnowflakeOnlineStore(OnlineStore):
         with get_snowflake_conn(config.online_store) as conn:
             for table in tables:
                 online_path = get_snowflake_online_store_path(config, table)
-                query = f'DROP TABLE IF EXISTS {online_path}."[online-hybrid] {config.project}_{table.name}"'
+                query = f'DROP TABLE IF EXISTS {online_path}."{config.online_store.table_type} {config.project}_{table.name}"'
                 execute_snowflake_statement(conn, query)

--- a/sdk/python/feast/infra/utils/snowflake/snowflake_utils.py
+++ b/sdk/python/feast/infra/utils/snowflake/snowflake_utils.py
@@ -120,6 +120,14 @@ def get_snowflake_online_store_path(
     return online_path
 
 
+def get_snowflake_online_table_fully_qualified_name(
+    config: RepoConfig,
+    feature_view: FeatureView,
+) -> str:
+    online_path = get_snowflake_online_store_path(config, feature_view)
+    return f'{online_path}."{config.online_store.table_type_fqn} {config.project}_{feature_view.name}"'
+
+
 def package_snowpark_zip(project_name) -> Tuple[str, str]:
     path = os.path.dirname(feast.__file__)
     copy_path = path + f"/snowflake_feast_{project_name}"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style--linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests
4. Make sure documentation is updated for your PR!
5. Make sure your commits are signed: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#signing-off-commits
6. Make sure your PR title follows conventional commits (e.g. fix: [description] vs feat: [description])

-->

**What this PR does / why we need it**:

High chance this doesn't work, but in theory would allow us to pass config option to choose hybrid or transient table for the Snowflake online feature store

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #
